### PR TITLE
fix: svg for react 18

### DIFF
--- a/src/CastButton/chromecast.svg
+++ b/src/CastButton/chromecast.svg
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink" xmlnsSketch="http://www.bohemiancoding.com/sketch/ns">
     <!-- Generator: Sketch 3.2.2 (9983) - http://www.bohemiancoding.com/sketch -->
     <title>ic_cast_black_24dp</title>
     <desc>Created with Sketch.</desc>
     <defs></defs>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
-        <g id="ic_cast_black_24dp" sketch:type="MSArtboardGroup">
-            <g id="ic_remove_circle_white_24dp" sketch:type="MSLayerGroup">
-                <path d="M1,18 L1,21 L4,21 C4,19.34 2.66,18 1,18 L1,18 Z M1,14 L1,16 C3.76,16 6,18.24 6,21 L8,21 C8,17.13 4.87,14 1,14 L1,14 Z M1,10 L1,12 C5.97,12 10,16.03 10,21 L12,21 C12,14.92 7.07,10 1,10 L1,10 Z M21,3 L3,3 C1.9,3 1,3.9 1,5 L1,8 L3,8 L3,5 L21,5 L21,19 L14,19 L14,21 L21,21 C22.1,21 23,20.1 23,19 L23,5 C23,3.9 22.1,3 21,3 L21,3 Z" id="cast" fill="#000000" sketch:type="MSShapeGroup"></path>
-                <rect id="bounds" sketch:type="MSShapeGroup" x="0" y="0" width="100%" height="100%"></rect>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketchType="MSPage">
+        <g id="ic_cast_black_24dp" sketchType="MSArtboardGroup">
+            <g id="ic_remove_circle_white_24dp" sketchType="MSLayerGroup">
+                <path d="M1,18 L1,21 L4,21 C4,19.34 2.66,18 1,18 L1,18 Z M1,14 L1,16 C3.76,16 6,18.24 6,21 L8,21 C8,17.13 4.87,14 1,14 L1,14 Z M1,10 L1,12 C5.97,12 10,16.03 10,21 L12,21 C12,14.92 7.07,10 1,10 L1,10 Z M21,3 L3,3 C1.9,3 1,3.9 1,5 L1,8 L3,8 L3,5 L21,5 L21,19 L14,19 L14,21 L21,21 C22.1,21 23,20.1 23,19 L23,5 C23,3.9 22.1,3 21,3 L21,3 Z" id="cast" fill="#000000" sketchType="MSShapeGroup"></path>
+                <rect id="bounds" sketchType="MSShapeGroup" x="0" y="0" width="100%" height="100%"></rect>
             </g>
         </g>
-        <g id="assets" sketch:type="MSLayerGroup" transform="translate(-208.000000, -106.000000)">
+        <g id="assets" sketchType="MSLayerGroup" transform="translate(-208.000000, -106.000000)">
             <g id="64px" transform="translate(0.000000, 114.000000)"></g>
         </g>
     </g>


### PR DESCRIPTION
I've fixed the svg to be used in react versions upper react 16, 